### PR TITLE
Config with root is not default "/" then the generated json file's url will be incorrect

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function hexo_generator_tipue_search_json(site) {
                         return actualPost[item] = post.tags.map(catags).join(' ');
 
                     case 'url':
-                        return actualPost[item] = '/' + post['path'];
+                        return actualPost[item] = hexo.config.root + post['path'];
 
                     default:
                         return actualPost[item] = post[item];
@@ -54,7 +54,7 @@ function hexo_generator_tipue_search_json(site) {
                     return actualPage[item] = minify(page.content);
 
                 case 'url':
-                    return actualPage[item] = '/' + page['path'];
+                    return actualPage[item] = hexo.config.root + page['path'];
 
                 default:
                     return actualPage[item] = page[item];


### PR DESCRIPTION
我自己的博客配置设置了`root`为子目录，结果导致用 Tipue Search 搜索出来的结果 URL 全部错误，所以需要在生成 JSON 的时候添加上 `root` 的配置。
改动如下：
```
case 'url': 
    return actualPage[item] = hexo.config.root + page['path'];
```